### PR TITLE
Refactor environment loading into constants module

### DIFF
--- a/cloudflare_browser_render/config.py
+++ b/cloudflare_browser_render/config.py
@@ -1,10 +1,11 @@
 """Configuration for Cloudflare Browser Rendering CLI."""
 
-import os
+from __future__ import annotations
 
-from dotenv import load_dotenv
-
-load_dotenv()
+from cloudflare_browser_render.utils.constant import (
+    CLOUDFLARE_ACCOUNT_ID,
+    CLOUDFLARE_API_TOKEN,
+)
 
 API_TOKEN_ENV = "CLOUDFLARE_API_TOKEN"
 ACCOUNT_ID_ENV = "CLOUDFLARE_ACCOUNT_ID"
@@ -20,7 +21,7 @@ def get_api_token() -> str:
         RuntimeError: If the API token is not found in environment variables.
 
     """
-    token = os.getenv(API_TOKEN_ENV)
+    token = CLOUDFLARE_API_TOKEN
     if not token:
         raise RuntimeError(f"{API_TOKEN_ENV} not found in environment or .env file")
     return token
@@ -36,7 +37,7 @@ def get_account_id() -> str:
         RuntimeError: If the Account ID is not found in environment variables.
 
     """
-    account_id = os.getenv(ACCOUNT_ID_ENV)
+    account_id = CLOUDFLARE_ACCOUNT_ID
     if not account_id:
         raise RuntimeError(f"{ACCOUNT_ID_ENV} not found in environment or .env file")
     return account_id

--- a/cloudflare_browser_render/utils/__init__.py
+++ b/cloudflare_browser_render/utils/__init__.py
@@ -1,5 +1,7 @@
 """Utility helpers for CLI operations."""
 
+from __future__ import annotations
+
 import json
 import time
 from collections.abc import Callable
@@ -15,6 +17,15 @@ except ImportError:  # pragma: no cover – fallback for old SDKs
     RateLimitError = Exception  # type: ignore  # noqa: N816
 
 T = TypeVar("T")
+
+__all__ = [
+    "RateLimitError",
+    "call_with_retry",
+    "console",
+    "print_json",
+    "save_bytes",
+    "save_text",
+]
 
 console = Console()
 

--- a/cloudflare_browser_render/utils/constant.py
+++ b/cloudflare_browser_render/utils/constant.py
@@ -1,0 +1,15 @@
+"""Application-wide configuration constants."""
+
+from __future__ import annotations
+
+from .env_loader import load_project_env
+
+_ENV = load_project_env()
+
+CLOUDFLARE_API_TOKEN: str = _ENV.get("CLOUDFLARE_API_TOKEN", "")
+CLOUDFLARE_ACCOUNT_ID: str = _ENV.get("CLOUDFLARE_ACCOUNT_ID", "")
+
+__all__ = [
+    "CLOUDFLARE_ACCOUNT_ID",
+    "CLOUDFLARE_API_TOKEN",
+]

--- a/cloudflare_browser_render/utils/env_loader.py
+++ b/cloudflare_browser_render/utils/env_loader.py
@@ -1,0 +1,15 @@
+"""Environment loading utilities for the CLI."""
+
+from __future__ import annotations
+
+import os
+from functools import lru_cache
+
+from dotenv import load_dotenv
+
+
+@lru_cache(maxsize=1)
+def load_project_env() -> dict[str, str]:
+    """Load environment variables once for the entire application."""
+    load_dotenv()
+    return dict(os.environ)

--- a/cloudflare_browser_render/utils/env_loader.py
+++ b/cloudflare_browser_render/utils/env_loader.py
@@ -10,6 +10,11 @@ from dotenv import load_dotenv
 
 @lru_cache(maxsize=1)
 def load_project_env() -> dict[str, str]:
-    """Load environment variables once for the entire application."""
+    """Load environment variables once for the entire application.
+
+    Returns:
+        dict[str, str]: A copy of the environment variables after loading
+        values from a `.env` file when present.
+    """
     load_dotenv()
     return dict(os.environ)

--- a/scripts/manual_verification.py
+++ b/scripts/manual_verification.py
@@ -1,8 +1,6 @@
-#!/usr/bin/env python3
-"""scripts/manual_verification.py.
+"""Automated wrapper for manual CLI verification using Python.
 
-Automated wrapper for manual CLI verification using Python.
-Loads environment variables from a .env file via python-dotenv and then
+Loads environment variables through the package constants module and then
 executes each `cloudflare-render` subcommand through PDM.
 
 Usage:
@@ -15,26 +13,30 @@ Example:
     # Ensure .env contains CLOUDFLARE_API_TOKEN and CLOUDFLARE_ACCOUNT_ID
     pdm install
     python scripts/manual_verification.py https://example.com "h1.title"
-
 """
 
 from __future__ import annotations
 
-import os
 import subprocess
 import sys
 from pathlib import Path
 
-from dotenv import load_dotenv
+from cloudflare_browser_render.config import ACCOUNT_ID_ENV, API_TOKEN_ENV
+from cloudflare_browser_render.utils.constant import (
+    CLOUDFLARE_ACCOUNT_ID,
+    CLOUDFLARE_API_TOKEN,
+)
 
 
 def ensure_env() -> None:
-    """Load .env and validate required environment variables."""
+    """Validate required environment variables via the constants module."""
     env_path = Path.cwd() / ".env"
-    load_dotenv(dotenv_path=env_path if env_path.exists() else None)
 
-    required = ["CLOUDFLARE_API_TOKEN", "CLOUDFLARE_ACCOUNT_ID"]
-    missing = [var for var in required if not os.getenv(var)]
+    required = {
+        API_TOKEN_ENV: CLOUDFLARE_API_TOKEN,
+        ACCOUNT_ID_ENV: CLOUDFLARE_ACCOUNT_ID,
+    }
+    missing = [var for var, value in required.items() if not value]
     if missing:
         print(
             f"[ERROR] Missing required environment variables: {', '.join(missing)}.\n"
@@ -43,7 +45,10 @@ def ensure_env() -> None:
         )
         sys.exit(1)
 
-    print(f"[INFO] Environment variables loaded from {env_path}")
+    if env_path.exists():
+        print(f"[INFO] Environment variables loaded from {env_path}")
+    else:
+        print("[INFO] Environment variables loaded from the active shell")
 
 
 def run_command(cmd: list[str]) -> None:


### PR DESCRIPTION
## Summary
- convert `cloudflare_browser_render.utils` into a package and add a cached environment loader
- expose Cloudflare credentials through `utils.constant` and update config to consume those constants
- update the manual verification script to validate configuration via the shared constants module

## Testing
- `pytest -q` *(fails: requires pytest-cov plugin which is unavailable in the execution environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6913c602a704832b9b1f391b4811a801)